### PR TITLE
Add base url to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ app.get("/", function(request, response) {
 	var uri = oauth2.getAuthorizationUrl({
 		redirect_uri: callbackUrl,
 		client_id: consumerKey,
-		scope: 'api'
+		scope: 'api',
+		// You can change loginUrl to connect to sandbox or prerelease env.
+		//base_url: 'test.my.salesforce.com'
 	});
 	return response.redirect(uri);
 });
@@ -40,7 +42,9 @@ app.get('/oauth/callback', function(request, response) {
 		redirect_uri: callbackUrl,
 		client_id: consumerKey,
 		client_secret: consumerSecret,
-		code: authorizationCode
+		code: authorizationCode,
+		// You can change loginUrl to connect to sandbox or prerelease env.
+		//base_url: 'test.my.salesforce.com'
 	}, function(error, payload) {
 		/*
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ app.get("/", function(request, response) {
 		client_id: consumerKey,
 		scope: 'api',
 		// You can change loginUrl to connect to sandbox or prerelease env.
-		//base_url: 'test.my.salesforce.com'
+		//base_url: 'https://test.my.salesforce.com'
 	});
 	return response.redirect(uri);
 });
@@ -44,7 +44,7 @@ app.get('/oauth/callback', function(request, response) {
 		client_secret: consumerSecret,
 		code: authorizationCode,
 		// You can change loginUrl to connect to sandbox or prerelease env.
-		//base_url: 'test.my.salesforce.com'
+		//base_url: 'https://test.my.salesforce.com'
 	}, function(error, payload) {
 		/*
 


### PR DESCRIPTION
You need to specify base_url for sandbox oauth or you will get invalid_grant authentication errors. Would have been helpful to have this in the docs