### PR TITLE
Follow redirects during HTTP POST calls to Salesforce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:   
-  - 0.10
+  - 4

--- a/lib/salesforce-oauth2.js
+++ b/lib/salesforce-oauth2.js
@@ -26,7 +26,9 @@ var oauth2 = module.exports = function (options, callback) {
 
     return request.post({
         url: uri,
-        proxy: proxyUrl
+        proxy: proxyUrl,
+        followAllRedirects: true,
+        followOriginalHttpMethod: true
     }, function (err, response) {
         if (err) {
             return callback(err);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "lib/salesforce-oauth2",
   "version": "0.1.8",
   "dependencies": {
-    "request": "~2.37.0",
+    "request": "~2.85.0",
     "underscore": "~1.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "should": "~4.0.4"
   },
   "engines": {
-    "node": "> 0.10"
+    "node": ">= 4"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha"


### PR DESCRIPTION
When making a call to a lightning domain, for example `customer.lightning.force.com`, the salesforce instance will return a `302 Found` to the equivalent `customer.my.salesforce.com` domain.

The default behavior of the `request` library is to only follow redirects on GET requests, meaning that the library doesn't follow the redirect on the `POST /services/oauth2/token` call, and then doesn't detect the 300-series response as an error and attempts to parse an empty response as JSON, resulting in:

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at Request._callback (/release/rest-server/node_modules/salesforce-oauth2/lib/salesforce-oauth2.js:41:28)
    at Request.self.callback (/release/rest-server/node_modules/salesforce-oauth2/node_modules/request/request.js:122:22)
    at emitTwo (events.js:126:13)
    at Request.emit (events.js:214:7)
    at Request.<anonymous> (/release/rest-server/node_modules/salesforce-oauth2/node_modules/request/request.js:1019:14)
    at emitOne (events.js:121:20)
    at Request.emit (events.js:211:7)
    at IncomingMessage.<anonymous> (/release/rest-server/node_modules/salesforce-oauth2/node_modules/request/request.js:970:12)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at IncomingMessage.wrapped (/release/rest-server/node_modules/newrelic/lib/transaction/tracer/index.js:181:22)
    at IncomingMessage.wrappedResponseEmit (/release/rest-server/node_modules/newrelic/lib/instrumentation/core/http-outbound.js:98:26)
    at endReadableNT (_stream_readable.js:1056:12)
    at wrapped (/release/rest-server/node_modules/newrelic/lib/transaction/tracer/index.js:181:22)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickDomainCallback [as _tickCallback] (internal/process/next_tick.js:218:9)
```

If the `request.post()` call is configured with `followAllRedirects` and `followOriginalHttpMethod`, the 302 response should be followed and the follow-up call should be successful.

From https://github.com/request/request/:
> * followRedirect - follow HTTP 3xx responses as redirects (default: true). This property can also be implemented as function which gets response object as a single argument and should return true if redirects should continue or false otherwise.
> * followAllRedirects - follow non-GET HTTP 3xx responses as redirects (default: false)
> * followOriginalHttpMethod - by default we redirect to HTTP method GET. you can enable this property to redirect to the original HTTP method (default: false)

An alternative solution here would be to change the error handling code:

```
if (response.statusCode >= 400) {
```

to

```
if (response.statusCode >= 300) {
```

and fail-fast instead.
